### PR TITLE
update for lucene/solr 6.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.apache.lucene</groupId>
     <artifactId>TurkishAnalysis</artifactId>
-    <version>6.0.0</version>
+    <version>6.2.1</version>
     <packaging>jar</packaging>
 
     <name>TurkishAnalysis</name>

--- a/src/main/java/org/apache/lucene/App.java
+++ b/src/main/java/org/apache/lucene/App.java
@@ -54,7 +54,7 @@ public class App {
             " * limitations under the License.\n" +
             " */\n" +
             "\n" +
-            "import org.apache.lucene.analysis.util.CharArrayMap;\n" +
+            "import org.apache.lucene.analysis.CharArrayMap;\n" +
             "\n" +
             "final class Map%c {\n" +
             "\n" +

--- a/src/main/java/org/apache/lucene/analysis/tr/TurkishDeASCIIfyFilter.java
+++ b/src/main/java/org/apache/lucene/analysis/tr/TurkishDeASCIIfyFilter.java
@@ -23,7 +23,7 @@ import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
 import org.apache.lucene.analysis.tokenattributes.PositionIncrementAttribute;
 import org.apache.lucene.analysis.tokenattributes.TypeAttribute;
 import org.apache.lucene.analysis.tr.util.PatternTableFactory;
-import org.apache.lucene.analysis.util.CharArrayMap;
+import org.apache.lucene.analysis.CharArrayMap;
 
 import java.io.IOException;
 import java.util.Arrays;

--- a/src/main/java/org/apache/lucene/analysis/tr/util/PatternTableFactory.java
+++ b/src/main/java/org/apache/lucene/analysis/tr/util/PatternTableFactory.java
@@ -17,7 +17,7 @@ package org.apache.lucene.analysis.tr.util;
  * limitations under the License.
  */
 
-import org.apache.lucene.analysis.util.CharArrayMap;
+import org.apache.lucene.analysis.CharArrayMap;
 
 import java.util.Collections;
 import java.util.HashMap;


### PR DESCRIPTION
(org.apache.lucene.analysis.utils.CharArrayMap is moved to org.apache.lucene.analysis.CharArrayMap on lucene source, all references are updated.)
